### PR TITLE
Update qt5 to qt6

### DIFF
--- a/README_for_developers.md
+++ b/README_for_developers.md
@@ -43,9 +43,13 @@ mamba activate nin-qgis-env
 poetry install
 ```
 
-### Symbolic Link to QGIS Plugin Directory (Windows only)
+### Symbolic Link to QGIS Plugin Directory
 
-To use the plugin in QGIS, create a symbolic link from the plugin folder to the QGIS profile directory. Open PowerShell **as administrator** and run:
+To use the plugin in QGIS during development, create a symbolic link from the plugin folder to the QGIS profile directory. Replace `QGIS3` with `QGIS4` in the paths below if you are using QGIS 4.
+
+#### Windows
+
+Open PowerShell **as administrator** and run:
 
 ```powershell
 New-Item -ItemType SymbolicLink `
@@ -53,12 +57,33 @@ New-Item -ItemType SymbolicLink `
   -Target "<path_to_nin_qgis_plugin>\nin_qgis_plugin"
 ```
 
-For example, with a default QGIS installation path:
+For example, with a default QGIS 3 installation path:
 
 ```powershell
 New-Item -ItemType SymbolicLink `
   -Path "C:\Users\<user>\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\nin-qgis-plugin" `
   -Target "C:\Users\<user>\Documents\GitHub\nin-qgis-plugin\nin_qgis_plugin"
+```
+
+#### macOS
+
+```bash
+ln -s <path_to_nin_qgis_plugin>/nin_qgis_plugin \
+  "$HOME/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/nin_qgis_plugin"
+```
+
+For example, with QGIS 3:
+
+```bash
+ln -s /Users/<user>/Documents/GitHub/nin-qgis-plugin/nin_qgis_plugin \
+  "/Users/<user>/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/nin_qgis_plugin"
+```
+
+Or with QGIS 4:
+
+```bash
+ln -s /Users/<user>/Documents/GitHub/nin-qgis-plugin/nin_qgis_plugin \
+  "/Users/<user>/Library/Application Support/QGIS/QGIS4/profiles/default/python/plugins/nin_qgis_plugin"
 ```
 
 ---

--- a/nin_qgis_plugin/attr_table_settings/edit_form_config.py
+++ b/nin_qgis_plugin/attr_table_settings/edit_form_config.py
@@ -31,14 +31,13 @@ def adjust_layer_edit_form(layer: QgsVectorLayer) -> QgsVectorLayer:
     # to 3.32 it was handled differently
     qgis_version = Qgis.version().split(".")
 
-    if int(qgis_version[0]) >= 3:
-        if int(qgis_version[1]) < 32:
-            edit_form_config.setLayout(1)
-        else:
-            # Change to 'TabLayout', aka Drag and drop layout
-            edit_form_config.setLayout(
-                Qgis.AttributeFormLayout(1)
-            )
+    if int(qgis_version[0]) >= 4 or (int(qgis_version[0]) == 3 and int(qgis_version[1]) >= 32):
+        # Change to 'TabLayout', aka Drag and drop layout
+        edit_form_config.setLayout(
+            Qgis.AttributeFormLayout(1)
+        )
+    elif int(qgis_version[0]) == 3:
+        edit_form_config.setLayout(1)
     else:
         raise NotImplementedError(
             f"Your Qgis version '{Qgis.version()}' is not supported, please download latest."

--- a/nin_qgis_plugin/create_gpkg.py
+++ b/nin_qgis_plugin/create_gpkg.py
@@ -27,17 +27,17 @@ def get_qvariant(qvariant: str) -> Any:
     '''
 
     if qvariant == 'Int':
-        return QVariant.Int
+        return QVariant.Type.Int
     if qvariant == 'String':
-        return QVariant.String
+        return QVariant.Type.String
     if qvariant == 'Date':
-        return QVariant.Date
+        return QVariant.Type.Date
     if qvariant == 'Double':
-        return QVariant.Double
+        return QVariant.Type.Double
     if qvariant == 'DateTime':
-        return QVariant.DateTime
+        return QVariant.Type.DateTime
     if qvariant == 'Bool':
-        return QVariant.Bool
+        return QVariant.Type.Bool
     raise ValueError("Qvariant Type not supported!")
 
 
@@ -264,7 +264,7 @@ def main(
 
     with edit(helper_point_layer):
         provider = helper_point_layer.dataProvider()
-        provider.addAttributes([QgsField("Comment", QVariant.String)])
+        provider.addAttributes([QgsField("Comment", QVariant.Type.String)])
         helper_point_layer.updateFields()
 
     write_layer_to_gpkg_file(

--- a/nin_qgis_plugin/create_gpkg.py
+++ b/nin_qgis_plugin/create_gpkg.py
@@ -43,11 +43,11 @@ FIELD_DEFINITIONS_CSV_PATH = Path(__file__).parent / \
 def get_qvariant(qvariant: str) -> Any:
     '''
     Returns QVariant object for corresponding short-hand strings.
-    Raises an error if provided string does not match a supported Qvariant type.
+    Raises an error if provided string does not match a supported QVariant type.
     '''
 
     if qvariant not in _FIELD_TYPES:
-        raise ValueError("Qvariant Type not supported!")
+        raise ValueError(f"QVariant type '{qvariant}' not supported!")
     return _FIELD_TYPES[qvariant]
 
 

--- a/nin_qgis_plugin/create_gpkg.py
+++ b/nin_qgis_plugin/create_gpkg.py
@@ -14,6 +14,26 @@ from qgis.core import (
 )
 from qgis.PyQt.QtCore import QVariant
 
+try:
+    from qgis.PyQt.QtCore import QMetaType
+    _FIELD_TYPES = {
+        'Int': QMetaType.Type.Int,
+        'String': QMetaType.Type.QString,
+        'Date': QMetaType.Type.QDate,
+        'Double': QMetaType.Type.Double,
+        'DateTime': QMetaType.Type.QDateTime,
+        'Bool': QMetaType.Type.Bool,
+    }
+except (ImportError, AttributeError):
+    _FIELD_TYPES = {
+        'Int': QVariant.Int,
+        'String': QVariant.String,
+        'Date': QVariant.Date,
+        'Double': QVariant.Double,
+        'DateTime': QVariant.DateTime,
+        'Bool': QVariant.Bool,
+    }
+
 ATTRIBUTE_TABLES_PATH = Path(__file__).parent / 'csv' / \
     'attribute_tables'
 FIELD_DEFINITIONS_CSV_PATH = Path(__file__).parent / \
@@ -26,19 +46,9 @@ def get_qvariant(qvariant: str) -> Any:
     Raises an error if provided string does not match a supported Qvariant type.
     '''
 
-    if qvariant == 'Int':
-        return QVariant.Type.Int
-    if qvariant == 'String':
-        return QVariant.Type.String
-    if qvariant == 'Date':
-        return QVariant.Type.Date
-    if qvariant == 'Double':
-        return QVariant.Type.Double
-    if qvariant == 'DateTime':
-        return QVariant.Type.DateTime
-    if qvariant == 'Bool':
-        return QVariant.Type.Bool
-    raise ValueError("Qvariant Type not supported!")
+    if qvariant not in _FIELD_TYPES:
+        raise ValueError("Qvariant Type not supported!")
+    return _FIELD_TYPES[qvariant]
 
 
 def create_empty_layer(
@@ -264,7 +274,7 @@ def main(
 
     with edit(helper_point_layer):
         provider = helper_point_layer.dataProvider()
-        provider.addAttributes([QgsField("Comment", QVariant.Type.String)])
+        provider.addAttributes([QgsField("Comment", _FIELD_TYPES['String'])])
         helper_point_layer.updateFields()
 
     write_layer_to_gpkg_file(

--- a/nin_qgis_plugin/metadata.txt
+++ b/nin_qgis_plugin/metadata.txt
@@ -22,7 +22,15 @@ repository=https://github.com/geco-nhm/nin-qgis-plugin.git
 
 hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
-# changelog=
+changelog=
+    0.4:
+    - Added QGIS 4.0 and Qt6 compatibility (qgisMaximumVersion=4.99)
+    - Replaced all direct PyQt5 imports with qgis.PyQt abstraction layer
+    - Fully qualified Qt enums for Qt6 (e.g. Qt.ItemDataRole.UserRole, Qt.CheckState.Checked)
+    - Fixed QVariant field types to use QMetaType.Type on Qt6, with Qt5 fallback
+    - Fixed edit form layout version check for QGIS 4
+    - Removed deprecated QFileDialog.ReadOnly option from .ui file
+    - Fixed duplicate nin_polygons layer in layer tree
 
 # Tags are comma separated with spaces allowed
 tags=python, field mapping, Norway, NiN, 

--- a/nin_qgis_plugin/metadata.txt
+++ b/nin_qgis_plugin/metadata.txt
@@ -5,8 +5,9 @@
 [general]
 name=Natur i Norge kartlegging
 qgisMinimumVersion=3.34.8
+qgisMaximumVersion=4.99
 description=Natur i Norge (NiN) mapping tool.
-version=0.3
+version=0.4
 author=Lasse Keetz, Peter Horvath, Anne B. Nilsen
 email=peter.horvath@nhm.uio.no
 

--- a/nin_qgis_plugin/metadata.txt
+++ b/nin_qgis_plugin/metadata.txt
@@ -24,12 +24,10 @@ hasProcessingProvider=no
 # Uncomment the following line and add your changelog:
 changelog=
     0.4:
-    - Added QGIS 4.0 and Qt6 compatibility (qgisMaximumVersion=4.99)
-    - Replaced all direct PyQt5 imports with qgis.PyQt abstraction layer
-    - Fully qualified Qt enums for Qt6 (e.g. Qt.ItemDataRole.UserRole, Qt.CheckState.Checked)
-    - Fixed QVariant field types to use QMetaType.Type on Qt6, with Qt5 fallback
-    - Fixed edit form layout version check for QGIS 4
-    - Removed deprecated QFileDialog.ReadOnly option from .ui file
+    - QGIS 4.0 / Qt6 compatibility
+    - Updated CSV tables from NiN-Kode API (2026)
+    - Added timeout logic for API requests
+    - Improved test coverage
     - Fixed duplicate nin_polygons layer in layer tree
 
 # Tags are comma separated with spaces allowed

--- a/nin_qgis_plugin/nin_qgis_plugin.py
+++ b/nin_qgis_plugin/nin_qgis_plugin.py
@@ -28,7 +28,7 @@ from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication, Qt
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction
 from qgis.core import QgsVectorLayer, QgsField, QgsProject, QgsFeature
-from PyQt5.QtCore import QVariant
+from qgis.PyQt.QtCore import QVariant
 
 # Initialize Qt resources from file resources.py
 from .resources import *

--- a/nin_qgis_plugin/nin_qgis_plugin_dialog.py
+++ b/nin_qgis_plugin/nin_qgis_plugin_dialog.py
@@ -30,16 +30,13 @@ from . import create_gpkg as cgpkg
 from . import project_setup as ps
 
 from qgis.PyQt import QtWidgets, uic
-from qgis.PyQt.QtCore import pyqtSignal
-from qgis.gui import QgsFileWidget
-# from PyQt5 import QtWidgets, uic
-from PyQt5.QtCore import Qt  # Import Qt from PyQt5.QtCore
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtCore import QUrl #for linking to github
-from PyQt5.QtWidgets import (
+from qgis.PyQt.QtCore import pyqtSignal, Qt, QUrl
+from qgis.PyQt.QtGui import QDesktopServices
+from qgis.PyQt.QtWidgets import (
     QMessageBox, QComboBox, QListWidget,
     QListWidgetItem, QGroupBox, QCheckBox, QRadioButton, QHBoxLayout
 )
+from qgis.gui import QgsFileWidget
 
 FORM_CLASS, _ = uic.loadUiType(os.path.join(
     os.path.dirname(__file__), 'nin_qgis_plugin_dialog_base.ui'
@@ -158,11 +155,11 @@ class NinMapperDialogWidget(QtWidgets.QDialog, FORM_CLASS):
                     # Creating a new list item for each matching row.
                     item = QListWidgetItem(row['navn'])
                     # Setting the display text and additional data for the list item.
-                    item.setData(Qt.UserRole, row['kode_id'])
+                    item.setData(Qt.ItemDataRole.UserRole, row['kode_id'])
                     # Making the list item checkable and setting its initial check state.
-                    item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+                    item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
                     # Set initial state to unchecked
-                    item.setCheckState(Qt.Unchecked)
+                    item.setCheckState(Qt.CheckState.Unchecked)
                     # Adding the list item to the QListWidget.
                     self.selectHovetypegrupperWidget.addItem(item)
 
@@ -172,11 +169,11 @@ class NinMapperDialogWidget(QtWidgets.QDialog, FORM_CLASS):
         selected_items = []
         for index in range(self.selectHovetypegrupperWidget.count()):
             item = self.selectHovetypegrupperWidget.item(index)
-            if item.checkState() == Qt.Checked:
+            if item.checkState() == Qt.CheckState.Checked:
                 selected_items.append({
                     'display_text': item.text(),
                     # Retrieve associated data
-                    'kode_id': item.data(Qt.UserRole)
+                    'kode_id': item.data(Qt.ItemDataRole.UserRole)
                 })
 
         return selected_items
@@ -215,7 +212,7 @@ class NinMapperDialogWidget(QtWidgets.QDialog, FORM_CLASS):
 
         # Set 'typer' combo box default
         self.comboBox.setCurrentIndex(
-            self.comboBox.findText("C-PE-NA Natursystem", Qt.MatchFixedString)
+            self.comboBox.findText("C-PE-NA Natursystem", Qt.MatchFlag.MatchFixedString)
         )
 
         # Setting default values for QListWidget
@@ -223,11 +220,11 @@ class NinMapperDialogWidget(QtWidgets.QDialog, FORM_CLASS):
         items_to_select = ["NA-T Fastmarkssystemer"]
         for item_to_select in items_to_select:
             items = self.selectHovetypegrupperWidget.findItems(
-                item_to_select, Qt.MatchExactly
+                item_to_select, Qt.MatchFlag.MatchExactly
             )
             for item in items:
                 # This sets the item as selected
-                item.setCheckState(Qt.Checked)
+                item.setCheckState(Qt.CheckState.Checked)
 
     def load_project(self) -> None:
         '''

--- a/nin_qgis_plugin/nin_qgis_plugin_dialog_base.ui
+++ b/nin_qgis_plugin/nin_qgis_plugin_dialog_base.ui
@@ -60,9 +60,6 @@
       <property name="storageMode">
        <enum>QgsFileWidget::SaveFile</enum>
       </property>
-      <property name="options">
-       <set>QFileDialog::ReadOnly</set>
-      </property>
      </widget>
     </item>
     <item row="1" column="0">

--- a/nin_qgis_plugin/project_setup.py
+++ b/nin_qgis_plugin/project_setup.py
@@ -442,9 +442,6 @@ class ProjectSetup:
             # Refresh layer
             layer.triggerRepaint()
 
-            # Add the layer to the project
-            QGS_PROJECT.addMapLayer(layer)
-
         # Layer is "nin_polygons" hard coded in def_init
         layer.saveStyleToDatabase(layer.name(),"Default style for {}".format(layer.name()),True,"")
 

--- a/nin_qgis_plugin/project_setup.py
+++ b/nin_qgis_plugin/project_setup.py
@@ -27,7 +27,7 @@ from qgis.core import (
     Qgis,               # for AvoidIntersectionsMode
     edit
 )
-from PyQt5.QtGui import QColor, QFont
+from qgis.PyQt.QtGui import QColor, QFont
 
 from .attr_table_settings.value_relations import get_value_relations
 from .attr_table_settings.default_values import get_default_values

--- a/nin_qgis_plugin/resources.py
+++ b/nin_qgis_plugin/resources.py
@@ -6,7 +6,7 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore
+from qgis.PyQt import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x04\x0a\

--- a/nin_qgis_plugin/resources.py
+++ b/nin_qgis_plugin/resources.py
@@ -2,9 +2,12 @@
 
 # Resource object code
 #
-# Created by: The Resource Compiler for PyQt5 (Qt v5.15.2)
+# Originally created by: The Resource Compiler for PyQt5 (Qt v5.15.2)
 #
-# WARNING! All changes made in this file will be lost!
+# NOTE: This file was manually patched to use qgis.PyQt instead of PyQt5
+# for Qt5/Qt6 compatibility. If you regenerate this file with pyrcc5,
+# you must re-apply the import change below:
+#   from PyQt5 import QtCore  ->  from qgis.PyQt import QtCore
 
 from qgis.PyQt import QtCore
 


### PR DESCRIPTION
    - Added QGIS 4.0 and Qt6 compatibility (qgisMaximumVersion=4.99)
    - Replaced all direct PyQt5 imports with qgis.PyQt abstraction layer
    - Fully qualified Qt enums for Qt6 (e.g. Qt.ItemDataRole.UserRole, Qt.CheckState.Checked)
    - Fixed QVariant field types to use QMetaType.Type on Qt6, with Qt5 fallback
    - Fixed edit form layout version check for QGIS 4
    - Removed deprecated QFileDialog.ReadOnly option from .ui file
    - Fixed duplicate nin_polygons layer in layer tree